### PR TITLE
use androidx.biometrics to support devices since android 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ captures/
 .idea/dictionaries
 .idea/libraries
 .idea/caches
+.idea/codeStyles/Project.xml
+.idea/
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.

--- a/app-kotlin/build.gradle
+++ b/app-kotlin/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
-  buildToolsVersion rootProject.ext.buildToolsVersion
 
   defaultConfig {
     applicationId "pwittchen.github.com.rxbiometric"
@@ -36,9 +35,9 @@ android {
 dependencies {
   implementation project(':library')
   implementation deps.kotlinstdlib
-  implementation deps.appcompatv7
+  implementation deps.appcompat
   implementation deps.constraintlayout
-  implementation deps.design
+  implementation deps.material
 }
 
 buildscript {

--- a/app-kotlin/src/main/kotlin/pwittchen/github/com/rxbiometric/MainActivity.kt
+++ b/app-kotlin/src/main/kotlin/pwittchen/github/com/rxbiometric/MainActivity.kt
@@ -18,14 +18,13 @@ package pwittchen.github.com.rxbiometric
 import android.content.DialogInterface
 import android.os.Build
 import android.os.Bundle
-import android.os.CancellationSignal
-import android.support.annotation.RequiresApi
-import android.support.v7.app.AppCompatActivity
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatActivity
 import android.widget.Toast
+import androidx.core.app.ActivityCompat
 import com.github.pwittchen.rxbiometric.library.RxBiometric
 import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationError
 import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationFail
-import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationHelp
 import com.github.pwittchen.rxbiometric.library.throwable.BiometricNotSupported
 import com.github.pwittchen.rxbiometric.library.validation.RxPreconditions
 import io.reactivex.Completable
@@ -38,7 +37,7 @@ import kotlinx.android.synthetic.main.content_main.button
 
 class MainActivity : AppCompatActivity() {
 
-  private lateinit var disposable: Disposable
+  private var disposable: Disposable? = null
 
   @RequiresApi(Build.VERSION_CODES.P)
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -48,34 +47,33 @@ class MainActivity : AppCompatActivity() {
 
 
     button.setOnClickListener { _ ->
-      disposable = RxPreconditions
-        .canHandleBiometric(this)
-        .flatMapCompletable {
-          if (!it) Completable.error(BiometricNotSupported())
-          else
-            RxBiometric
-              .title("title")
-              .description("description")
-              .negativeButtonText("cancel")
-              .negativeButtonListener(DialogInterface.OnClickListener { _, _ ->
-                showMessage("cancel")
-              })
-              .cancellationSignal(CancellationSignal())
-              .executor(mainExecutor)
-              .build()
-              .authenticate(this)
-        }
-        .subscribeOn(Schedulers.io())
+      disposable =
+        RxPreconditions
+          .canHandleBiometric(this)
+          .flatMapCompletable {
+            if (!it) Completable.error(BiometricNotSupported())
+            else
+              RxBiometric
+                .title("title")
+                .description("description")
+                .negativeButtonText("cancel")
+                .negativeButtonListener(DialogInterface.OnClickListener { _, _ ->
+                  showMessage("cancel")
+                })
+                .executor(ActivityCompat.getMainExecutor(this@MainActivity))
+                .build()
+                .authenticate(this)
+          }
         .observeOn(AndroidSchedulers.mainThread())
         .subscribeBy(
           onComplete = { showMessage("authenticated!") },
           onError = {
             when (it) {
-              is AuthenticationError -> showMessage("error")
+              is AuthenticationError -> showMessage("error: ${it.errorCode} ${it.errorMessage}")
               is AuthenticationFail -> showMessage("fail")
-              is AuthenticationHelp -> showMessage("help")
-              is BiometricNotSupported -> showMessage("biometric not supported")
-              else -> showMessage("other error")
+              else -> {
+                showMessage("other error")
+              }
             }
           }
         )
@@ -84,8 +82,10 @@ class MainActivity : AppCompatActivity() {
 
   override fun onPause() {
     super.onPause()
-    if (!disposable.isDisposed) {
-      disposable.dispose()
+    disposable?.let {
+      if (!it.isDisposed) {
+        it.dispose()
+      }
     }
   }
 

--- a/app-kotlin/src/main/res/layout/activity_main.xml
+++ b/app-kotlin/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -8,13 +8,13 @@
     tools:context=".MainActivity"
     >
 
-  <android.support.design.widget.AppBarLayout
+  <com.google.android.material.appbar.AppBarLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:theme="@style/AppTheme.AppBarOverlay"
       >
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
@@ -22,8 +22,8 @@
         app:popupTheme="@style/AppTheme.PopupOverlay"
         />
 
-  </android.support.design.widget.AppBarLayout>
+  </com.google.android.material.appbar.AppBarLayout>
 
   <include layout="@layout/content_main"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app-kotlin/src/main/res/layout/content_main.xml
+++ b/app-kotlin/src/main/res/layout/content_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -17,4 +17,4 @@
       android:layout_height="wrap_content"
       />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,11 @@ ext.deps = [
               rxjava2             : 'io.reactivex.rxjava2:rxjava:2.2.0',
               rxandroid2          : 'io.reactivex.rxjava2:rxandroid:2.0.2',
               rxkotlin2           : 'io.reactivex.rxjava2:rxkotlin:2.3.0',
-              supportannotations  : 'com.android.support:support-annotations:28.0.0-rc01',
-              appcompatv7         : 'com.android.support:appcompat-v7:28.0.0-rc01',
+              annotations         : 'androidx.annotation:annotation:1.0.1',
+              appcompat           : 'androidx.appcompat:appcompat:1.1.0-alpha01',
+              material            : 'com.google.android.material:material:1.1.0-alpha02',
               design              : 'com.android.support:design:28.0.0-rc01',
-              constraintlayout    : 'com.android.support.constraint:constraint-layout:1.1.2',
+              constraintlayout    : 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3',
               junit               : 'junit:junit:4.12',
               truth               : 'com.google.truth:truth:0.42',
               robolectric         : 'org.robolectric:robolectric:4.0-alpha-3',
@@ -26,7 +27,8 @@ ext.deps = [
               ktlintgradle        : "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:4.1.0",
               kotlinx             : "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion",
               kotlinstdlib        : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",
-              kotlingradleplugin  : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"]
+              kotlingradleplugin  : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
+              biometrics          : "androidx.biometric:biometric:1.0.0-alpha03"]
 
 buildscript {
   repositories {
@@ -39,7 +41,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.4'
+    classpath 'com.android.tools.build:gradle:3.2.1'
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
   }

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -24,7 +24,7 @@ task findbugs(type: FindBugs) {
     effort = "max"
     reportLevel = "high"
     excludeFilter = new File("${project.rootDir}/config/quality/findbugs/findbugs-filter.xml")
-    classes = files("${project.rootDir}/library/build/intermediates/classes")
+    classes = files("${project.rootDir}/library/build/intermediates/javac")
 
     source 'src'
     include '**/*.java'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ POM_DEVELOPER_NAME=Piotr Wittchen
 
 org.gradle.daemon=true
 org.gradle.jvmargs=-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx2048m
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 22 09:36:31 CEST 2018
+#Mon Jan 07 18:12:02 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,7 +11,6 @@ apply from: '../maven_push.gradle'
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
-  buildToolsVersion rootProject.ext.buildToolsVersion
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
@@ -127,7 +126,8 @@ dependencies {
   api deps.rxjava2
   api deps.rxandroid2
   api deps.rxkotlin2
-  implementation deps.supportannotations
+  implementation deps.annotations
+  implementation deps.biometrics
   implementation deps.kotlinstdlib
   testImplementation deps.junit
   testImplementation deps.truth

--- a/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/Authentication.kt
+++ b/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/Authentication.kt
@@ -15,20 +15,16 @@
  */
 package com.github.pwittchen.rxbiometric.library
 
-import android.hardware.biometrics.BiometricPrompt.AuthenticationCallback
-import android.hardware.biometrics.BiometricPrompt.AuthenticationResult
-import android.os.Build
-import android.support.annotation.RequiresApi
+import androidx.biometric.BiometricPrompt.AuthenticationCallback
+import androidx.biometric.BiometricPrompt.AuthenticationResult
 import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationError
 import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationFail
-import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationHelp
 import io.reactivex.CompletableEmitter
 
 open class Authentication {
-  @RequiresApi(Build.VERSION_CODES.P)
   fun createAuthenticationCallback(it: CompletableEmitter): AuthenticationCallback {
     return object : AuthenticationCallback() {
-      override fun onAuthenticationSucceeded(result: AuthenticationResult?) {
+      override fun onAuthenticationSucceeded(result: AuthenticationResult) {
         it.onComplete()
       }
 
@@ -38,16 +34,9 @@ open class Authentication {
 
       override fun onAuthenticationError(
         errorCode: Int,
-        errorMessage: CharSequence?
+        errorMessage: CharSequence
       ) {
         it.tryOnError(AuthenticationError(errorCode, errorMessage))
-      }
-
-      override fun onAuthenticationHelp(
-        helpCode: Int,
-        helpMessage: CharSequence?
-      ) {
-        it.tryOnError(AuthenticationHelp(helpCode, helpMessage))
       }
     }
   }

--- a/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/RxBiometricBuilder.kt
+++ b/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/RxBiometricBuilder.kt
@@ -16,7 +16,6 @@
 package com.github.pwittchen.rxbiometric.library
 
 import android.content.DialogInterface
-import android.os.CancellationSignal
 import com.github.pwittchen.rxbiometric.library.RxBiometric.Companion
 import java.util.concurrent.Executor
 
@@ -25,7 +24,6 @@ class RxBiometricBuilder {
   internal lateinit var description: String
   internal lateinit var negativeButtonText: String
   internal lateinit var negativeButtonListener: DialogInterface.OnClickListener
-  internal lateinit var cancellationSignal: CancellationSignal
   internal lateinit var executor: Executor
 
   fun title(title: String): RxBiometricBuilder {
@@ -45,11 +43,6 @@ class RxBiometricBuilder {
 
   fun negativeButtonListener(negativeButtonListener: DialogInterface.OnClickListener): RxBiometricBuilder {
     this.negativeButtonListener = negativeButtonListener
-    return this
-  }
-
-  fun cancellationSignal(cancellationSignal: CancellationSignal): RxBiometricBuilder {
-    this.cancellationSignal = cancellationSignal
     return this
   }
 

--- a/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/validation/RxPreconditions.kt
+++ b/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/validation/RxPreconditions.kt
@@ -29,10 +29,7 @@ class RxPreconditions {
     }
 
     @JvmStatic fun canHandleBiometric(context: Context): Single<Boolean> {
-      return hasBiometricSupport(context).flatMap { it ->
-        if (it) isAtLeastAndroidPie()
-        else Single.just(false)
-      }
+      return hasBiometricSupport(context)
     }
   }
 }

--- a/library/src/test/kotlin/com/github/pwittchen/rxbiometric/library/AuthenticationTest.kt
+++ b/library/src/test/kotlin/com/github/pwittchen/rxbiometric/library/AuthenticationTest.kt
@@ -15,11 +15,10 @@
  */
 package com.github.pwittchen.rxbiometric.library
 
-import android.hardware.biometrics.BiometricPrompt.AuthenticationCallback
-import android.hardware.biometrics.BiometricPrompt.AuthenticationResult
+import androidx.biometric.BiometricPrompt.AuthenticationCallback
+import androidx.biometric.BiometricPrompt.AuthenticationResult
 import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationError
 import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationFail
-import com.github.pwittchen.rxbiometric.library.throwable.AuthenticationHelp
 import io.reactivex.CompletableEmitter
 import org.junit.Before
 import org.junit.Test
@@ -64,13 +63,5 @@ class AuthenticationTest {
 
     // then
     verify(emitter).tryOnError(any(AuthenticationError::class.java))
-  }
-
-  @Test fun shouldTryOnErrorOnAuthenticationHelp() {
-    // when
-    callback.onAuthenticationHelp(2, "help needed")
-
-    // then
-    verify(emitter).tryOnError(any(AuthenticationHelp::class.java))
   }
 }


### PR DESCRIPTION
Thanks for the review, I create a new pull request to keep original for reference.

Changes I made:

1. lateinit disposable will be uninitialized and cause crash if button not pushed and put activity to back.
2. hasBiometrics support now does not check android version, only check fingerprint support
3. AuthenticationCallback in androidx support library only has three methods, success, fail, error. Help message now include in fail message.
4. Now require an activity to bring up fingerprint, if activity onPause, fingerprint dialog will automatically be cancelled. 