### PR TITLE
Add setDeviceCredentialAllowed()

### DIFF
--- a/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/RxBiometric.kt
+++ b/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/RxBiometric.kt
@@ -28,8 +28,9 @@ class RxBiometric {
   companion object {
     private lateinit var title: String
     private lateinit var description: String
-    private lateinit var negativeButtonText: String
-    private lateinit var negativeButtonListener: DialogInterface.OnClickListener
+    private var negativeButtonText: String? = null
+    private var deviceCredentialAllowed: Boolean = false
+    private var negativeButtonListener: DialogInterface.OnClickListener? = null
     private lateinit var executor: Executor
     private lateinit var promptInfo: BiometricPrompt.PromptInfo
 
@@ -41,11 +42,17 @@ class RxBiometric {
       this.description = builder.description
       this.negativeButtonText = builder.negativeButtonText
       this.negativeButtonListener = builder.negativeButtonListener
+      this.deviceCredentialAllowed = builder.deviceCredentialAllowed
       this.executor = builder.executor
-      this.promptInfo = BiometricPrompt.PromptInfo.Builder()
+      val promptBuilder = BiometricPrompt.PromptInfo.Builder()
+        .setDeviceCredentialAllowed(deviceCredentialAllowed)
         .setTitle(title)
         .setDescription(description)
-        .setNegativeButtonText(negativeButtonText).build()
+
+      negativeButtonText?.let {
+        promptBuilder.setNegativeButtonText(it)
+      }
+      this.promptInfo = promptBuilder.build()
       return this
     }
 
@@ -57,6 +64,11 @@ class RxBiometric {
     @JvmStatic
     fun title(title: String): RxBiometricBuilder {
       return builder().title(title)
+    }
+
+    @JvmStatic
+    fun deviceCredentialAllowed(enable: Boolean): RxBiometricBuilder {
+      return builder().deviceCredentialAllowed(enable)
     }
 
     @JvmStatic
@@ -74,7 +86,8 @@ class RxBiometric {
       return builder().negativeButtonListener(listener)
     }
 
-    @JvmStatic fun executor(executor: Executor): RxBiometricBuilder {
+    @JvmStatic
+    fun executor(executor: Executor): RxBiometricBuilder {
       return builder().executor(executor)
     }
 

--- a/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/RxBiometricBuilder.kt
+++ b/library/src/main/kotlin/com/github/pwittchen/rxbiometric/library/RxBiometricBuilder.kt
@@ -22,9 +22,15 @@ import java.util.concurrent.Executor
 class RxBiometricBuilder {
   internal lateinit var title: String
   internal lateinit var description: String
-  internal lateinit var negativeButtonText: String
-  internal lateinit var negativeButtonListener: DialogInterface.OnClickListener
+  internal var negativeButtonText: String? = null
+  internal var negativeButtonListener: DialogInterface.OnClickListener? = null
   internal lateinit var executor: Executor
+  internal var deviceCredentialAllowed: Boolean = false
+
+  fun deviceCredentialAllowed(enable: Boolean): RxBiometricBuilder {
+    this.deviceCredentialAllowed = enable
+    return this
+  }
 
   fun title(title: String): RxBiometricBuilder {
     this.title = title


### PR DESCRIPTION
According to [docs](https://developer.android.com/reference/androidx/biometric/BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed(boolean)), PromptInfo.Builder has `setDeviceCredentialAllowed()` function. This PR adds it to the library.